### PR TITLE
Fix matching application/json content-type with charset

### DIFF
--- a/src/RequestHandler.ts
+++ b/src/RequestHandler.ts
@@ -138,7 +138,7 @@ class RequestHandler extends EventEmitter {
 
 					// 429 and 502 are recoverable and will be re-tried automatically with 3 attempts max.
 					if (request.statusCode && !Constants.OK_STATUS_CODES.includes(request.statusCode) && ![429, 502].includes(request.statusCode)) {
-						const e = new DiscordAPIError(endpoint, request.headers["content-type"]?.startsWith("application/json") ? await request.json() : request.body, method, request.statusCode);
+						const e = new DiscordAPIError(endpoint, request.headers["content-type"]?.startsWith("application/json") ? await request.json() : request.body.toString(), method, request.statusCode);
 						e.stack = stack;
 						throw e;
 					}

--- a/src/RequestHandler.ts
+++ b/src/RequestHandler.ts
@@ -138,7 +138,7 @@ class RequestHandler extends EventEmitter {
 
 					// 429 and 502 are recoverable and will be re-tried automatically with 3 attempts max.
 					if (request.statusCode && !Constants.OK_STATUS_CODES.includes(request.statusCode) && ![429, 502].includes(request.statusCode)) {
-						const e = new DiscordAPIError(endpoint, request.headers["content-type"] === "application/json" ? await request.json() : request.body, method, request.statusCode);
+						const e = new DiscordAPIError(endpoint, request.headers["content-type"]?.startsWith("application/json") ? await request.json() : request.body, method, request.statusCode);
 						e.stack = stack;
 						throw e;
 					}


### PR DESCRIPTION
Thanks a lot @PapiOphidian for the big update! :)

-----

While the Discord API returns exactly `application/json` as a content-type, some proxies (like the ones you can use to handle ratelimits when you write a microservice-based bot) may append a charset like this:

    Content-Type: application/json; charset=utf-8

This is a valid header (and Discord may also send the charset in the future), so it should be accepted