### PR TITLE
Unref Ratelimiter.globalResetTimeout to not block the event loop

### DIFF
--- a/src/Ratelimiter.ts
+++ b/src/Ratelimiter.ts
@@ -41,7 +41,7 @@ class Ratelimiter {
 			const instance = this;
 			this.globalResetTimeout = setTimeout(() => {
 				instance.global = false;
-			}, this.globalReset);
+			}, this.globalReset).unref();
 		} else {
 			if (this.globalResetTimeout) clearTimeout(this.globalResetTimeout);
 			this.globalResetTimeout = null;


### PR DESCRIPTION
Currently, the event loop is being blocked by the `Ratelimiter.globalResetTimeout`, preventing the application from naturally exiting.
This change [unref()](https://nodejs.org/dist/latest-v16.x/docs/api/timers.html#timeoutunref) the timer to allow the Node.js's process to exit where there is nothing else blocking the event loop.