### PR TITLE
Update the list of required options for Channel.createMessage()

### DIFF
--- a/src/methods/Channels.ts
+++ b/src/methods/Channels.ts
@@ -189,7 +189,7 @@ export class ChannelMethods {
 	 * client.channel.createMessage("channel id", { content: "This is a nice picture", files: [{ name: "Optional_Filename.png", file: fileData }] })
 	 */
 	public async createMessage(channelId: string, data: string | CreateMessageData, options: { disableEveryone?: boolean; } = { disableEveryone: this.disableEveryone }): Promise<import("discord-typings").Message> {
-		if (typeof data !== "string" && !data.content && !data.embeds && !data.files) throw new Error("Missing content, embeds, files");
+		if (typeof data !== "string" && !data.content && !data.embeds && !data.sticker_ids && !data.components && !data.files) throw new Error("Missing content, embeds, sticker_ids, components, or files");
 		if (typeof data === "string") data = { content: data };
 
 		// Sanitize the message
@@ -367,7 +367,6 @@ export class ChannelMethods {
 	 * client.channel.editMessage("channel id", message.id, `pong ${Date.now() - time}ms`)
 	 */
 	public async editMessage(channelId: string, messageId: string, data: string | EditMessageData, options: { disableEveryone?: boolean; } = { disableEveryone: this.disableEveryone }): Promise<import("discord-typings").Message> {
-		if (typeof data !== "string" && data.content === undefined && data.embeds === undefined && data.files === undefined) throw new Error("Missing content, embeds, or files");
 		if (typeof data === "string") data = { content: data };
 
 		// Sanitize the message

--- a/src/methods/Webhooks.ts
+++ b/src/methods/Webhooks.ts
@@ -163,7 +163,7 @@ export class WebhookMethods {
 	public async executeWebhook(webhookId: string, token: string, data: WebhookCreateMessageData, options?: { wait?: false; disableEveryone?: boolean; thread_id?: string; }): Promise<void>;
 	public async executeWebhook(webhookId: string, token: string, data: WebhookCreateMessageData, options: { wait: true; disableEveryone?: boolean; thread_id?: string; }): Promise<import("discord-typings").Message>;
 	public async executeWebhook(webhookId: string, token: string, data: WebhookCreateMessageData, options: { wait?: boolean; disableEveryone?: boolean; thread_id?: string; } | undefined = { disableEveryone: this.disableEveryone }): Promise<void | import("discord-typings").Message> {
-		if (typeof data !== "string" && !data?.content && !data?.embeds && !data?.files) throw new Error("Missing content or embeds or files");
+		if (typeof data !== "string" && !data?.content && !data?.embeds && !data?.components && !data?.files) throw new Error("Missing content or embeds or components or files");
 		if (typeof data === "string") data = { content: data };
 
 		// Sanitize the message


### PR DESCRIPTION
`sticker_ids` and `components` were missing in `Channel.createMessage()` (and `Webhook.executeWebhook()` for the latter).

I've also removed the check for `editMessage()` because "All parameters to this endpoint are optional and nullable." [as per the doc](https://discord.com/developers/docs/resources/channel#edit-message) (for example, you may want to update only the `flags`).