### PR TITLE
feat: Add option to set a default `allowed_mentions`

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,6 +1,7 @@
 import { Blob, File } from "buffer";
 import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
+import { deprecate } from "util";
 
 const mentionRegex = /@([^<>@ ]*)/gsmu;
 const isValidUserMentionRegex = /^[&!]?\d+$/;
@@ -51,9 +52,9 @@ const Constants = {
 			form.set(name, blob, filename);
 		} else throw new Error(`Don't know how to add ${value?.constructor?.name ?? typeof value} to form`);
 	},
-	replaceEveryone(content: string): string {
+	replaceEveryone: deprecate(function replaceEveryone(content: string): string {
 		return content.replace(mentionRegex, replaceEveryoneMatchProcessor);
-	}
+	}, "SnowTransfer: disableEveryone option has been deprecated and will be removed in a future release. Please use allowed_mentions instead.")
 };
 
 export = Constants;

--- a/src/SnowTransfer.ts
+++ b/src/SnowTransfer.ts
@@ -25,7 +25,8 @@ namespace SnowTransfer {
 		baseHost: string;
 		/** The default allowed_mentions object to send when creating/updating messages */
 		allowed_mentions: APIAllowedMentions | undefined;
-		/** If methods that send messages should have their content processed to remove [at]everyone and [at]here */
+		/** If methods that send messages should have their content processed to remove [at]everyone and [at]here
+		 * @deprecated Use {@link Options.allowed_mentions allowed_mentions} instead */
 		disableEveryone: boolean;
 		/** If rate limit buckets should be totally bypassed and functions are executed as fast as possible. Only use if you are 100% certain you wont run into issues or if you are proxying */
 		bypassBuckets: boolean;

--- a/src/SnowTransfer.ts
+++ b/src/SnowTransfer.ts
@@ -17,14 +17,14 @@ import WebhookMethods = require("./methods/Webhook");
 import Endpoints = require("./Endpoints");
 import Constants = require("./Constants");
 
-/**
- * @since 0.1.0
- */
-class SnowTransfer {
-	/** Options for this SnowTransfer instance */
-	public options: {
+import type { APIAllowedMentions } from 'discord-api-types/v10';
+
+namespace SnowTransfer {
+	export type Options = {
 		/** The URL to start requests from. eg: https://discord.com */
 		baseHost: string;
+		/** The default allowed_mentions object to send when creating/updating messages */
+		allowed_mentions: APIAllowedMentions | undefined;
 		/** If methods that send messages should have their content processed to remove [at]everyone and [at]here */
 		disableEveryone: boolean;
 		/** If rate limit buckets should be totally bypassed and functions are executed as fast as possible. Only use if you are 100% certain you wont run into issues or if you are proxying */
@@ -34,6 +34,14 @@ class SnowTransfer {
 		/** How many times requests should be retried if they fail and can be retried. */
 		retryLimit: number;
 	};
+}
+
+/**
+ * @since 0.1.0
+ */
+class SnowTransfer {
+	/** Options for this SnowTransfer instance */
+	public options: SnowTransfer.Options;
 	/** The access token to use for requests. Can be a bot or bearer token */
 	public token: string | undefined;
 	/** Methods related to channels */
@@ -79,7 +87,7 @@ class SnowTransfer {
 	public constructor(token?: string, options?: Partial<SnowTransfer["options"]>) {
 		if (typeof token === "string" && token === "") throw new Error("Missing token");
 		if (token && (!token.startsWith("Bot") && !token.startsWith("Bearer"))) token = `Bot ${token}`;
-		this.options = { baseHost: Endpoints.BASE_HOST, disableEveryone: false, bypassBuckets: false, retryRequests: false, retryLimit: Constants.DEFAULT_RETRY_LIMIT, ...options };
+		this.options = { baseHost: Endpoints.BASE_HOST, allowed_mentions: undefined, disableEveryone: false, bypassBuckets: false, retryRequests: false, retryLimit: Constants.DEFAULT_RETRY_LIMIT, ...options };
 		this.token = token;
 		this.ratelimiter = new Ratelimiter();
 		this.requestHandler = new RequestHandler(this.ratelimiter, {
@@ -89,14 +97,14 @@ class SnowTransfer {
 			retryFailed: this.options.retryRequests,
 			retryLimit: this.options.retryLimit
 		});
-		this.channel = new ChannelMethods(this.requestHandler, this.options.disableEveryone);
+		this.channel = new ChannelMethods(this.requestHandler, this.options);
 		this.user = new UserMethods(this.requestHandler);
 		this.assets = new AssetsMethods(this.requestHandler);
-		this.webhook = new WebhookMethods(this.requestHandler, this.options.disableEveryone);
+		this.webhook = new WebhookMethods(this.requestHandler, this.options);
 		this.guild = new GuildMethods(this.requestHandler);
 		this.guildScheduledEvent = new GuildScheduledEventMethods(this.requestHandler);
 		this.guildTemplate = new GuildTemplateMethods(this.requestHandler);
-		this.interaction = new InteractionMethods(this.requestHandler, this.webhook);
+		this.interaction = new InteractionMethods(this.requestHandler, this.webhook, this.options);
 		this.invite = new InviteMethods(this.requestHandler);
 		this.voice = new VoiceMethods(this.requestHandler);
 		this.bot = new BotMethods(this.requestHandler);

--- a/src/methods/Channel.ts
+++ b/src/methods/Channel.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler as RH, RESTPostAPIAttachmentsRefreshURLsResult } from "../RequestHandler";
+import type SnowTransfer = require("../SnowTransfer");
 
 import Endpoints = require("../Endpoints");
 import Constants = require("../Constants");
@@ -53,8 +54,6 @@ import {
 	type RESTGetAPIPollAnswerVotersQuery,
 	type RESTGetAPIPollAnswerVotersResult,
 	type RESTPostAPIPollExpireResult,
-
-	MessageFlags,
 	MessageReferenceType
 } from "discord-api-types/v10";
 
@@ -73,9 +72,9 @@ class ChannelMethods {
 	 *
 	 * You can access the methods listed via `client.channel.method`, where `client` is an initialized SnowTransfer instance
 	 * @param requestHandler request handler that calls the rest api
-	 * @param disableEveryone Disable [at]everyone/[at]here on outgoing messages
+	 * @param options Options for the SnowTransfer instance
 	 */
-	public constructor(public requestHandler: RH, public disableEveryone: boolean) {}
+	public constructor(public requestHandler: RH, public options: SnowTransfer.Options) {}
 
 	/**
 	 * Get a channel via Id
@@ -249,12 +248,13 @@ class ChannelMethods {
 	 * const fileData = fs.readFileSync("nice_picture.png") // You should probably use fs.promises.readFile, since it is asynchronous, synchronous methods block the thread.
 	 * client.channel.createMessage("channel id", { content: "This is a nice picture", files: [{ name: "Optional_Filename.png", file: fileData }] })
 	 */
-	public async createMessage(channelId: string, data: string | RESTPostAPIChannelMessageJSONBody & { files?: Array<{ name: string; file: Buffer | Readable | ReadableStream; }> }, options: { disableEveryone?: boolean; } = { disableEveryone: this.disableEveryone }): Promise<RESTPostAPIChannelMessageResult> {
+	public async createMessage(channelId: string, data: string | RESTPostAPIChannelMessageJSONBody & { files?: Array<{ name: string; file: Buffer | Readable | ReadableStream; }> }, options: { disableEveryone?: boolean; } = { disableEveryone: this.options.disableEveryone }): Promise<RESTPostAPIChannelMessageResult> {
 		if (typeof data !== "string" && !data.content && (!data.message_reference || (data.message_reference && data.message_reference.type === MessageReferenceType.Default)) && !data.embeds && !data.sticker_ids && !data.components && !data.files && !data.poll) throw new Error("Missing content, message_reference type 1, embeds, sticker_ids, components, files, or poll");
 		if (typeof data === "string") data = { content: data };
 
 		// Sanitize the message
-		if (data.content && (options.disableEveryone ?? this.disableEveryone)) data.content = Constants.replaceEveryone(data.content);
+		if (data.content && (options.disableEveryone ?? this.options.disableEveryone)) data.content = Constants.replaceEveryone(data.content);
+		data.allowed_mentions ??= this.options.allowed_mentions;
 
 		if (data.files) return this.requestHandler.request(Endpoints.CHANNEL_MESSAGES(channelId), {}, "post", "multipart", await Constants.standardMultipartHandler(data as Parameters<typeof Constants["standardMultipartHandler"]>["0"]));
 		else return this.requestHandler.request(Endpoints.CHANNEL_MESSAGES(channelId), {}, "post", "json", data);
@@ -486,11 +486,12 @@ class ChannelMethods {
 	 * const message = await client.channel.createMessage("channel id", "pong")
 	 * client.channel.editMessage("channel id", message.id, `pong ${Date.now() - time}ms`)
 	 */
-	public async editMessage(channelId: string, messageId: string, data: string | RESTPatchAPIChannelMessageJSONBody & { files?: Array<{ name: string; file: Buffer | Readable | ReadableStream; }> }, options: { disableEveryone?: boolean; } = { disableEveryone: this.disableEveryone }): Promise<RESTPatchAPIChannelMessageResult> {
+	public async editMessage(channelId: string, messageId: string, data: string | RESTPatchAPIChannelMessageJSONBody & { files?: Array<{ name: string; file: Buffer | Readable | ReadableStream; }> }, options: { disableEveryone?: boolean; } = { disableEveryone: this.options.disableEveryone }): Promise<RESTPatchAPIChannelMessageResult> {
 		if (typeof data === "string") data = { content: data };
 
 		// Sanitize the message
-		if (data.content && (options.disableEveryone ?? this.disableEveryone)) data.content = Constants.replaceEveryone(data.content);
+		if (data.content && (options.disableEveryone ?? this.options.disableEveryone)) data.content = Constants.replaceEveryone(data.content);
+		if (data.content || data.components) data.allowed_mentions ??= this.options.allowed_mentions;
 
 		if (data.files) return this.requestHandler.request(Endpoints.CHANNEL_MESSAGE(channelId, messageId), {}, "patch", "multipart", await Constants.standardMultipartHandler(data as Parameters<typeof Constants["standardMultipartHandler"]>["0"]));
 		else return this.requestHandler.request(Endpoints.CHANNEL_MESSAGE(channelId, messageId), {}, "patch", "json", data);

--- a/src/methods/Interaction.ts
+++ b/src/methods/Interaction.ts
@@ -1,40 +1,42 @@
 import Endpoints = require("../Endpoints");
 import Constants = require("../Constants");
 
-import type WHM = require("./Webhook");
 import type { RequestHandler as RH } from "../RequestHandler";
+import type WHM = require("./Webhook");
+import type SnowTransfer = require("../SnowTransfer");
 
-import type {
-	RESTDeleteAPIInteractionFollowupResult,
-	RESTDeleteAPIInteractionOriginalResponseResult,
-	RESTGetAPIApplicationCommandPermissionsResult,
-	RESTGetAPIApplicationCommandResult,
-	RESTGetAPIApplicationCommandsResult,
-	RESTGetAPIApplicationGuildCommandResult,
-	RESTGetAPIApplicationGuildCommandsResult,
-	RESTGetAPIInteractionFollowupResult,
-	RESTGetAPIInteractionOriginalResponseResult,
-	RESTPatchAPIApplicationCommandJSONBody,
-	RESTPatchAPIApplicationCommandResult,
-	RESTPatchAPIApplicationGuildCommandJSONBody,
-	RESTPatchAPIApplicationGuildCommandResult,
-	RESTPatchAPIInteractionFollowupJSONBody,
-	RESTPatchAPIInteractionFollowupResult,
-	RESTPatchAPIInteractionOriginalResponseJSONBody,
-	RESTPatchAPIInteractionOriginalResponseResult,
-	RESTPostAPIApplicationCommandsJSONBody,
-	RESTPostAPIApplicationCommandsResult,
-	RESTPostAPIApplicationGuildCommandsJSONBody,
-	RESTPostAPIApplicationGuildCommandsResult,
-	RESTPostAPIInteractionCallbackJSONBody,
-	RESTPostAPIInteractionFollowupJSONBody,
-	RESTPostAPIInteractionFollowupResult,
-	RESTPutAPIApplicationCommandPermissionsJSONBody,
-	RESTPutAPIApplicationCommandPermissionsResult,
-	RESTPutAPIApplicationCommandsJSONBody,
-	RESTPutAPIApplicationCommandsResult,
-	RESTPutAPIApplicationGuildCommandsJSONBody,
-	RESTPutAPIApplicationGuildCommandsResult
+import {
+	InteractionResponseType,
+	type RESTDeleteAPIInteractionFollowupResult,
+	type RESTDeleteAPIInteractionOriginalResponseResult,
+	type RESTGetAPIApplicationCommandPermissionsResult,
+	type RESTGetAPIApplicationCommandResult,
+	type RESTGetAPIApplicationCommandsResult,
+	type RESTGetAPIApplicationGuildCommandResult,
+	type RESTGetAPIApplicationGuildCommandsResult,
+	type RESTGetAPIInteractionFollowupResult,
+	type RESTGetAPIInteractionOriginalResponseResult,
+	type RESTPatchAPIApplicationCommandJSONBody,
+	type RESTPatchAPIApplicationCommandResult,
+	type RESTPatchAPIApplicationGuildCommandJSONBody,
+	type RESTPatchAPIApplicationGuildCommandResult,
+	type RESTPatchAPIInteractionFollowupJSONBody,
+	type RESTPatchAPIInteractionFollowupResult,
+	type RESTPatchAPIInteractionOriginalResponseJSONBody,
+	type RESTPatchAPIInteractionOriginalResponseResult,
+	type RESTPostAPIApplicationCommandsJSONBody,
+	type RESTPostAPIApplicationCommandsResult,
+	type RESTPostAPIApplicationGuildCommandsJSONBody,
+	type RESTPostAPIApplicationGuildCommandsResult,
+	type RESTPostAPIInteractionCallbackJSONBody,
+	type RESTPostAPIInteractionFollowupJSONBody,
+	type RESTPostAPIInteractionFollowupResult,
+	type RESTPutAPIApplicationCommandPermissionsJSONBody,
+	type RESTPutAPIApplicationCommandPermissionsResult,
+	type RESTPutAPIApplicationCommandsJSONBody,
+	type RESTPutAPIApplicationCommandsResult,
+	type RESTPutAPIApplicationGuildCommandsJSONBody,
+	type RESTPutAPIApplicationGuildCommandsResult
 } from "discord-api-types/v10";
 
 import type { Readable } from "stream";
@@ -54,7 +56,7 @@ class InteractionMethods {
 	 * @param requestHandler request handler that calls the rest api
 	 * @param webhooks WebhookMethods class that handles webhook related stuff
 	 */
-	public constructor(public requestHandler: RH, public webhooks: WHM) {}
+	public constructor(public requestHandler: RH, public webhooks: WHM, public options: SnowTransfer.Options) {}
 
 	/**
 	 * Fetch all global commands for your application
@@ -306,6 +308,11 @@ class InteractionMethods {
 	 * client.interaction.createInteractionResponse("interactionId", "token", { type: 4, data: { content: "Hello World" } })
 	 */
 	public async createInteractionResponse(interactionId: string, token: string, data: RESTPostAPIInteractionCallbackJSONBody & { files?: Array<{ name: string; file: Buffer | Readable | ReadableStream; }> }): Promise<void> {
+		if ((
+			data.type === InteractionResponseType.ChannelMessageWithSource ||
+			data.type === InteractionResponseType.UpdateMessage
+		) && data.data) data.data.allowed_mentions ??= this.options.allowed_mentions;
+
 		if (data.files) return this.requestHandler.request(Endpoints.INTERACTION_CALLBACK(interactionId, token), {}, "post", "multipart", await Constants.standardMultipartHandler(data as Parameters<typeof Constants["standardMultipartHandler"]>["0"]));
 		else return this.requestHandler.request(Endpoints.INTERACTION_CALLBACK(interactionId, token), {}, "post", "json", data);
 	}


### PR DESCRIPTION
For years, there has been such an option to enable the `disableEveryone` option globally.

`disableEveryone` is hack that was created when Discord didn't yet provide any option to prevent unexpected ping.

We now have a first party option to prevent unexpected pings, `allowed_mentions`, but adoption is complicated because it must be set on each individual message.

This PR allows lib users to set a default value for `allowed_mentions` that will be used if not explicitly overriden when posting a message.

---
Additionally, this PR deprecates the old `disableEveryone` option.

There is no actual reason to continue to use `disableEveryone` (which is more prone to failure, btw). Therefore, this PR marks the option as deprecated, and emits a deprecation warning when the internal `replaceEveryone` function is called for the first time.