### PR TITLE
fix(RequestHandler): Don't set Content-Type for DELETE requests

### DIFF
--- a/src/RequestHandler.ts
+++ b/src/RequestHandler.ts
@@ -527,9 +527,9 @@ export class RequestHandler extends EventEmitter<HandlerEvents> {
 		if (!disallowedBodyMethods.has(method)) {
 			if (typeof data === "object") body = JSON.stringify(data);
 			else body = String(data);
-		}
 
-		headers["Content-Type"] = "application/json";
+			headers["Content-Type"] = "application/json";
+		}
 
 		return fetch(`${this.apiURL}${endpoint}${appendQuery(params)}`, {
 			method: method.toUpperCase(),


### PR DESCRIPTION
We are not sending any body for DELETE requests, but we still set
Content-Type regardless.

Looks like a recent change on Discord broke these invalid requests, and
they now trigger "50109: The request body contains invalid JSON."

Can't really blame it on Discord since we are telling their server that
we are including a JSON body, but a 0-bytes body is not a valid JSON.