### PR TITLE
fix: Add support for the X-Audit-Log-Reason header where it's missing

### DIFF
--- a/src/methods/Channel.ts
+++ b/src/methods/Channel.ts
@@ -648,6 +648,7 @@ class ChannelMethods {
 	 * @since 0.7.0
 	 * @param channelId The Id of the announcement channel
 	 * @param webhookChannelId The Id of the channel messages will be sent to
+	 * @param reason Reason to show in the audit log
 	 * @returns A [followed channel](https://discord.com/developers/docs/resources/channel#followed-channel-object) object
 	 *
 	 * | Permissions needed | Condition |
@@ -659,8 +660,8 @@ class ChannelMethods {
 	 * const client = new SnowTransfer("TOKEN")
 	 * client.channel.followAnnouncementChannel("news channel id", "text channel id")
 	 */
-	public async followAnnouncementChannel(channelId: string, webhookChannelId: string): Promise<RESTPostAPIChannelFollowersResult> {
-		return this.requestHandler.request(Endpoints.CHANNEL_FOLLOWERS(channelId), {}, "post", "json", { webhook_channel_id: webhookChannelId });
+	public async followAnnouncementChannel(channelId: string, webhookChannelId: string, reason?: string): Promise<RESTPostAPIChannelFollowersResult> {
+		return this.requestHandler.request(Endpoints.CHANNEL_FOLLOWERS(channelId), {}, "post", "json", { webhook_channel_id: webhookChannelId, reason });
 	}
 
 	/**

--- a/src/methods/Guild.ts
+++ b/src/methods/Guild.ts
@@ -130,7 +130,7 @@ class GuildMethods {
 	 * }
 	 * client.guild.updateGuild("guild Id", guildData)
 	 */
-	public async updateGuild(guildId: string, data: RESTPatchAPIGuildJSONBody): Promise<RESTPatchAPIGuildResult> {
+	public async updateGuild(guildId: string, data: RESTPatchAPIGuildJSONBody & { reason?: string; }): Promise<RESTPatchAPIGuildResult> {
 		return this.requestHandler.request(Endpoints.GUILD(guildId), {}, "patch", "json", data);
 	}
 
@@ -191,7 +191,7 @@ class GuildMethods {
 	 * \}
 	 * const channel = await client.guild.createGuildChannel("guild id", channelData)
 	 */
-	public async createGuildChannel(guildId: string, data: RESTPostAPIGuildChannelJSONBody): Promise<RESTPostAPIGuildChannelResult> {
+	public async createGuildChannel(guildId: string, data: RESTPostAPIGuildChannelJSONBody & { reason?: string; }): Promise<RESTPostAPIGuildChannelResult> {
 		return this.requestHandler.request(Endpoints.GUILD_CHANNELS(guildId), {}, "post", "json", data);
 	}
 
@@ -342,7 +342,7 @@ class GuildMethods {
 	 * }
 	 * const member = await client.guild.updateGuildMember("guild Id", "memberId", memberData)
 	 */
-	public async updateGuildMember(guildId: string, memberId: string, data: RESTPatchAPIGuildMemberJSONBody): Promise<RESTPatchAPIGuildMemberResult> {
+	public async updateGuildMember(guildId: string, memberId: string, data: RESTPatchAPIGuildMemberJSONBody & { reason?: string; }): Promise<RESTPatchAPIGuildMemberResult> {
 		return this.requestHandler.request(Endpoints.GUILD_MEMBER(guildId, memberId), {}, "patch", "json", data);
 	}
 
@@ -601,7 +601,7 @@ class GuildMethods {
 	 * }
 	 * client.guild.updateGuildRole("guildId", "roleId", roleData)
 	 */
-	public async updateGuildRole(guildId: string, roleId: string, data: RESTPatchAPIGuildRoleJSONBody): Promise<RESTPatchAPIGuildRoleResult> {
+	public async updateGuildRole(guildId: string, roleId: string, data: RESTPatchAPIGuildRoleJSONBody & { reason?: string; }): Promise<RESTPatchAPIGuildRoleResult> {
 		return this.requestHandler.request(Endpoints.GUILD_ROLE(guildId, roleId), {}, "patch", "json", data);
 	}
 

--- a/src/methods/GuildScheduledEvent.ts
+++ b/src/methods/GuildScheduledEvent.ts
@@ -71,7 +71,7 @@ class GuildScheduledEventMethods {
 	 * }
 	 * const event = await client.guildScheduledEvent.createGuildScheduledEvent(guildId, eventData)
 	 */
-	public async createGuildScheduledEvent(guildId: string, data: RESTPostAPIGuildScheduledEventJSONBody): Promise<RESTPostAPIGuildScheduledEventResult> {
+	public async createGuildScheduledEvent(guildId: string, data: RESTPostAPIGuildScheduledEventJSONBody & { reason?: string; }): Promise<RESTPostAPIGuildScheduledEventResult> {
 		return this.requestHandler.request(Endpoints.GUILD_SCHEDULED_EVENTS(guildId), {}, "post", "json", data);
 	}
 
@@ -117,7 +117,7 @@ class GuildScheduledEventMethods {
 	 * const client = new SnowTransfer("TOKEN")
 	 * const event = await client.guildScheduledEvent.editGuildScheduledEvent(guildId, eventId, { entity_type: 3, channel_id: null, entity_metadata: { location: "Brazil" }, scheduled_end_time: "2025-01-01T00:00:00.000Z" })
 	 */
-	public async editGuildScheduledEvent(guildId: string, eventId: string, data: RESTPatchAPIGuildScheduledEventJSONBody): Promise<RESTPatchAPIGuildScheduledEventResult> {
+	public async editGuildScheduledEvent(guildId: string, eventId: string, data: RESTPatchAPIGuildScheduledEventJSONBody & { reason?: string; }): Promise<RESTPatchAPIGuildScheduledEventResult> {
 		return this.requestHandler.request(Endpoints.GUILD_SCHEDULED_EVENT(guildId, eventId), {}, "patch", "json", data);
 	}
 

--- a/src/methods/Invite.ts
+++ b/src/methods/Invite.ts
@@ -26,7 +26,7 @@ class InviteMethods {
 	/**
 	 * Get the invite data on an invite id
 	 * @since 0.1.0
-	 * @param inviteId Id of the invite
+	 * @param inviteId Code of the invite
 	 * @param options Query params for additional metadata fields
 	 * @returns [Invite Object](https://discord.com/developers/docs/resources/invite#invite-object)
 	 *
@@ -42,7 +42,8 @@ class InviteMethods {
 	/**
 	 * Delete an invite
 	 * @since 0.1.0
-	 * @param inviteId
+	 * @param inviteId The code of the invite to delete
+	 * @param reason The reason to show in the audit log
 	 * @returns [Invite Object](https://discord.com/developers/docs/resources/invite#invite-object)
 	 *
 	 * | Permissions needed | Condition                                     |
@@ -54,8 +55,8 @@ class InviteMethods {
 	 * const client = new SnowTransfer("TOKEN")
 	 * const invite = await client.invite.deleteInvite("inviteId")
 	 */
-	public async deleteInvite(inviteId: string): Promise<RESTDeleteAPIInviteResult> {
-		return this.requestHandler.request(Endpoints.INVITES(inviteId), {}, "delete", "json");
+	public async deleteInvite(inviteId: string, reason?: string): Promise<RESTDeleteAPIInviteResult> {
+		return this.requestHandler.request(Endpoints.INVITES(inviteId), {}, "delete", "json", { reason });
 	}
 }
 

--- a/src/methods/Webhook.ts
+++ b/src/methods/Webhook.ts
@@ -71,7 +71,7 @@ class WebhookMethods {
 	 * }
 	 * const webhook = await client.webhook.createWebhook("channel Id", webhookData)
 	 */
-	public async createWebhook(channelId: string, data: RESTPostAPIChannelWebhookJSONBody): Promise<RESTPostAPIChannelWebhookResult> {
+	public async createWebhook(channelId: string, data: RESTPostAPIChannelWebhookJSONBody & { reason?: string; }): Promise<RESTPostAPIChannelWebhookResult> {
 		return this.requestHandler.request(Endpoints.CHANNEL_WEBHOOKS(channelId), {}, "post", "json", data);
 	}
 
@@ -166,6 +166,7 @@ class WebhookMethods {
 	 * @since 0.1.0
 	 * @param webhookId Id of the webhook
 	 * @param token Webhook token
+	 * @param reason The reason to show in the audit log
 	 * @returns Resolves the Promise on successful execution
 	 *
 	 * | Permissions needed | Condition     |
@@ -177,9 +178,9 @@ class WebhookMethods {
 	 * const client = new SnowTransfer(); // No token needed if webhook token is provided
 	 * client.webhook.deleteWebhook("webhook Id", "webhook token")
 	 */
-	public async deleteWebhook(webhookId: string, token?: string): Promise<RESTDeleteAPIWebhookResult> {
-		if (token) return this.requestHandler.request(Endpoints.WEBHOOK_TOKEN(webhookId, token), {}, "delete", "json") as RESTDeleteAPIWebhookResult;
-		return this.requestHandler.request(Endpoints.WEBHOOK(webhookId), {}, "delete", "json") as RESTDeleteAPIWebhookResult;
+	public async deleteWebhook(webhookId: string, token?: string, reason?: string): Promise<RESTDeleteAPIWebhookResult> {
+		if (token) return this.requestHandler.request(Endpoints.WEBHOOK_TOKEN(webhookId, token), {}, "delete", "json", { reason }) as RESTDeleteAPIWebhookResult;
+		return this.requestHandler.request(Endpoints.WEBHOOK(webhookId), {}, "delete", "json", { reason }) as RESTDeleteAPIWebhookResult;
 	}
 
 	/**


### PR DESCRIPTION
I've checked all create/update/delete endpoints, they should all be covered now.